### PR TITLE
Openai model specification location

### DIFF
--- a/tool_configs.yaml
+++ b/tool_configs.yaml
@@ -49,6 +49,7 @@ openai:
     - gpt-4o-mini
     - gpt-4o
     - gpt-4.1-mini
+    - gpt-5.2-instant
   max_token: 3000
 
 

--- a/tool_configs.yaml
+++ b/tool_configs.yaml
@@ -49,7 +49,7 @@ openai:
     - gpt-4o-mini
     - gpt-4o
     - gpt-4.1-mini
-    - gpt-5.2-instant
+    - gpt-5.2
   max_token: 3000
 
 


### PR DESCRIPTION
Add `gpt-5.2-instant` to the list of available OpenAI models to make it selectable in the Generative Excel model dropdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fbf3db8-2371-43f3-bbe5-83436658d81e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9fbf3db8-2371-43f3-bbe5-83436658d81e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

